### PR TITLE
Add fedora messaging support

### DIFF
--- a/planet/config.py
+++ b/planet/config.py
@@ -112,6 +112,9 @@ def __init__():
     define_planet_int('feed_timeout', 20)
     define_planet_int('cache_keep_entries', 10)
 
+    # More bool than int
+    define_planet_int('fedora_messaging_enabled', 0)
+
     define_planet_list('template_files')
     define_planet_list('bill_of_materials')
     define_planet_list('template_directories', '.')


### PR DESCRIPTION
This adds the whole messaging schema for Fedora planet, together with changes in the planet itself.

To test the messaging schema:
```
$ python -m venv .venv
$ . .venv/bin/activate
$ pip install pytest fedora-messaging
$ cd fedora_planet_messages
$ pip install .
$ pytest fedora_planet_messages/
```

Signed-off-by: Michal Konečný <mkonecny@redhat.com>