### PR TITLE
Make the updated_parsed value an unix timestamp

### DIFF
--- a/planet/spider.py
+++ b/planet/spider.py
@@ -244,6 +244,10 @@ def writeCache(feed_uri, feed_info, data):
           continue
 
         if config.fedora_messaging_enabled() and not os.path.exists(cache_file):
+          # Convert the updated_parsed back to a unix timestamp as the
+          # time_structure format is not JSON serializable
+          entry['updated_parsed'] = time.mktime(entry['updated_parsed'])
+
           # If the cache file for this entry doesn't exist, then we can
           # somewhat safely assume we have never seen it before and that
           # it is "new"

--- a/planet/spider.py
+++ b/planet/spider.py
@@ -247,6 +247,8 @@ def writeCache(feed_uri, feed_info, data):
           # Convert the updated_parsed back to a unix timestamp as the
           # time_structure format is not JSON serializable
           entry['updated_parsed'] = time.mktime(entry['updated_parsed'])
+          if entry.get('published_parsed'):
+              entry['published_parsed'] = time.mktime(entry['published_parsed'])
 
           # If the cache file for this entry doesn't exist, then we can
           # somewhat safely assume we have never seen it before and that


### PR DESCRIPTION
Otherwise it is a time_structure object which is not JSON serializable,
which makes sending of the notification fail.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>